### PR TITLE
Fixed norlab_controllers_msgs type

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>norlab_controller_msgs</exec_depend>
+  <exec_depend>norlab_controllers_msgs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
`rosdep install` complained about missing dependency, and I realized there's a typo in the dependency name.